### PR TITLE
Role-Based Access Control (RBAC)

### DIFF
--- a/qconnect/app/middleware.ts
+++ b/qconnect/app/middleware.ts
@@ -28,6 +28,7 @@ export function middleware(req: NextRequest) {
 
       // Attach user info for downstream handlers
       const requestHeaders = new Headers(req.headers);
+      requestHeaders.set("x-user-id", String(decoded.id));
       requestHeaders.set("x-user-email", decoded.email);
       requestHeaders.set("x-user-role", decoded.role);
 

--- a/qconnect/src/context/AuthContext.tsx
+++ b/qconnect/src/context/AuthContext.tsx
@@ -1,7 +1,7 @@
 "use client";
 import React, { createContext, useState, useContext, ReactNode, useEffect } from "react";
 
-type User = { id?: number; name?: string; email?: string } | null;
+type User = { id?: number; name?: string; email?: string; role?: string } | null;
 
 interface AuthContextType {
   user: User;

--- a/qconnect/src/lib/rbac.ts
+++ b/qconnect/src/lib/rbac.ts
@@ -1,0 +1,11 @@
+export const ROLES = {
+  ADMIN: ["create", "read", "update", "delete"],
+  PATIENT: ["read"],
+};
+
+export function hasPermission(role: string | undefined, action: string) {
+  if (!role) return false;
+  const perms = (ROLES as any)[role.toUpperCase()];
+  if (!perms) return false;
+  return perms.includes(action);
+}


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Implement Role-Based Access Control (RBAC) system with permission checks

- Add user role and ID propagation through request headers

- Enforce delete permissions at API and UI layers

- Define role-permission mappings for admin and patient roles


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Middleware"] -->|"Extract role & id"| B["Request Headers"]
  B -->|"x-user-role, x-user-id"| C["DELETE API Route"]
  C -->|"Check permission"| D["RBAC Module"]
  D -->|"Verify admin or self"| E["Allow/Deny"]
  E -->|"Allowed"| F["Delete User"]
  F -->|"Success"| G["Response"]
  E -->|"Denied"| H["403 Error"]
  I["UI Component"] -->|"Check permission"| D
  I -->|"Show/Hide button"| J["Delete Button"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rbac.ts</strong><dd><code>Create RBAC module with permission mappings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

qconnect/src/lib/rbac.ts

<ul><li>Create new RBAC module with role-permission mappings<br> <li> Define ADMIN role with full CRUD permissions<br> <li> Define PATIENT role with read-only permission<br> <li> Implement <code>hasPermission()</code> function for permission validation</ul>


</details>


  </td>
  <td><a href="https://github.com/kalviumcommunity/S86-1225-Vertex-Full-Stack-With-NextjsAnd-AWS-Azure-QConnect/pull/27/files#diff-fca17d42306de492b8a0b172b0ae98d68b5ca338e2baf1abcc8750b8fa5e8e6f">+11/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>middleware.ts</strong><dd><code>Propagate user ID through request headers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

qconnect/app/middleware.ts

<ul><li>Add user ID to request headers via <code>x-user-id</code><br> <li> Propagate decoded user ID alongside existing email and role headers<br> <li> Enable downstream handlers to access user identity</ul>


</details>


  </td>
  <td><a href="https://github.com/kalviumcommunity/S86-1225-Vertex-Full-Stack-With-NextjsAnd-AWS-Azure-QConnect/pull/27/files#diff-8599ff9ce58d12e0eec223f4b1427fda43da6564e18550f4962db3594443b385">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>route.ts</strong><dd><code>Add RBAC authorization to user deletion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

qconnect/app/api/users/[id]/route.ts

<ul><li>Add RBAC check in DELETE endpoint before user deletion<br> <li> Extract user role and ID from request headers<br> <li> Allow deletion only if user is admin or deleting themselves<br> <li> Log RBAC check results for audit purposes</ul>


</details>


  </td>
  <td><a href="https://github.com/kalviumcommunity/S86-1225-Vertex-Full-Stack-With-NextjsAnd-AWS-Azure-QConnect/pull/27/files#diff-58be0db6e4d02f2f5c26adc00b61ba29db6a2346989a907560b4fda18e86ea78">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>UsersSWRList.tsx</strong><dd><code>Add UI-level permission guard for delete button</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

qconnect/src/components/users/UsersSWRList.tsx

<ul><li>Import <code>useAuth</code> hook and <code>hasPermission</code> function<br> <li> Add UI-level permission check before rendering delete button<br> <li> Show delete button only if user has delete permission or is deleting <br>self<br> <li> Prevent unauthorized users from seeing delete action</ul>


</details>


  </td>
  <td><a href="https://github.com/kalviumcommunity/S86-1225-Vertex-Full-Stack-With-NextjsAnd-AWS-Azure-QConnect/pull/27/files#diff-c2c7c59c793d9c495a86dda552a33c3ed1631570b1d1937a37f3dfd4c110cb86">+16/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AuthContext.tsx</strong><dd><code>Add role field to User type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

qconnect/src/context/AuthContext.tsx

<ul><li>Extend User type to include optional <code>role</code> field<br> <li> Enable role information to be stored and accessed in auth context</ul>


</details>


  </td>
  <td><a href="https://github.com/kalviumcommunity/S86-1225-Vertex-Full-Stack-With-NextjsAnd-AWS-Azure-QConnect/pull/27/files#diff-8104f28c89557a3f339b74ad5facb15eabf6b1d8a216f3fc9a661329e3ad9535">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

